### PR TITLE
Update plugin

### DIFF
--- a/plugin
+++ b/plugin
@@ -294,6 +294,7 @@
   "wassy92x/lovelace-entities-btn-group",
   "wassy92x/lovelace-ha-dashboard",
   "wilsto/pool-monitor-card",
+  "zanac/temperature-heatmap-card",
   "zanna-37/hass-swipe-navigation",
   "zeronounours/lovelace-energy-entity-row"
 ]


### PR DESCRIPTION
Heatmap Temperature Card

Link to current release: https://github.com/zanac/temperature-heatmap-card
Link to successful HACS action (without the `ignore` key): https://github.com/zanac/temperature-heatmap-card/actions/runs/5885227755


