### PR TITLE
Adds new plugin [zanac/temperature-heatmap-card]

### DIFF
--- a/plugin
+++ b/plugin
@@ -294,6 +294,7 @@
   "wassy92x/lovelace-entities-btn-group",
   "wassy92x/lovelace-ha-dashboard",
   "wilsto/pool-monitor-card",
+  "zanac/temperature-heatmap-card",
   "zanna-37/hass-swipe-navigation",
   "zeronounours/lovelace-energy-entity-row"
 ]


### PR DESCRIPTION
Adds new plugin [zanac/temperature-heatmap-card]

## Checklist
* [x]  I've read the [publishing documentation](https://hacs.xyz/docs/publish/start).
* [x]  I've added the [HACS action](https://hacs.xyz/docs/publish/action) to my repository.
* [ ]  N/A (For integrations only) I've added the [hassfest action](https://developers.home-assistant.io/blog/2020/04/16/hassfest/) to my repository.
* [x]  The actions are passing without any disabled checks in my repository.
* [x]  I've added a link to the action run on my repository below in the links section.
* [x]  I've created a new release of the repository after the validation actions were run successfully.

## Links
Link to current release: https://github.com/zanac/temperature-heatmap-card/releases/tag/v0.9
Link to successful HACS action (without the `ignore` key): https://github.com/zanac/temperature-heatmap-card/actions/runs/5885227755
Link to successful hassfest action (if integration): <N/A>

